### PR TITLE
Fix logout navigation to return to login page

### DIFF
--- a/lib/screens/response_page.dart
+++ b/lib/screens/response_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/login_response.dart';
+import 'login_page.dart';
 
 class ResponsePage extends StatelessWidget {
   static const routeName = '/response';
@@ -17,7 +18,11 @@ class ResponsePage extends StatelessWidget {
             tooltip: 'Logout',
             icon: const Icon(Icons.logout),
             onPressed: () {
-              Navigator.of(context).pop(); // back to login
+              Navigator.of(context).pushReplacement(
+                MaterialPageRoute(
+                  builder: (_) => const LoginPage(),
+                ),
+              );
             },
           ),
         ],


### PR DESCRIPTION
## Summary
- Ensure tapping logout replaces current route with login screen to prevent black screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1c64d2208320bb9d793b78ed4771