### PR TITLE
Enable searchable fabric roll selection after login

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'screens/login_page.dart';
-import 'screens/response_page.dart';
-import 'models/login_response.dart';
 
 void main() {
   runApp(const AuroraLoginApp());
@@ -19,13 +17,6 @@ class AuroraLoginApp extends StatelessWidget {
         useMaterial3: true,
       ),
       home: const LoginPage(),
-      onGenerateRoute: (settings) {
-        if (settings.name == ResponsePage.routeName) {
-          final data = settings.arguments as LoginResponse;
-          return MaterialPageRoute(builder: (_) => ResponsePage(data: data));
-        }
-        return null;
-      },
     );
   }
 }

--- a/lib/models/fabric_roll.dart
+++ b/lib/models/fabric_roll.dart
@@ -1,0 +1,22 @@
+class FabricRoll {
+  final String rollNo;
+  final String unit;
+  final double perRollWeight;
+  final String vendorName;
+
+  FabricRoll({
+    required this.rollNo,
+    required this.unit,
+    required this.perRollWeight,
+    required this.vendorName,
+  });
+
+  factory FabricRoll.fromJson(Map<String, dynamic> json) {
+    return FabricRoll(
+      rollNo: json['roll_no'] as String,
+      unit: json['unit'] as String,
+      perRollWeight: (json['per_roll_weight'] as num).toDouble(),
+      vendorName: json['vendor_name'] as String,
+    );
+  }
+}

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -20,7 +20,6 @@ class _LoginPageState extends State<LoginPage> {
   void dispose() {
     _usernameCtrl.dispose();
     _passwordCtrl.dispose();
-    _api.dispose();
     super.dispose();
   }
 
@@ -40,9 +39,14 @@ class _LoginPageState extends State<LoginPage> {
       );
 
       if (!mounted) return;
-      Navigator.of(
-        context,
-      ).pushReplacementNamed(ResponsePage.routeName, arguments: data);
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (_) => ResponsePage(
+            data: data,
+            api: _api,
+          ),
+        ),
+      );
     } on ApiException catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(

--- a/lib/screens/response_page.dart
+++ b/lib/screens/response_page.dart
@@ -1,15 +1,145 @@
 import 'package:flutter/material.dart';
 import '../models/login_response.dart';
+import '../models/fabric_roll.dart';
+import '../services/api_service.dart';
 import 'login_page.dart';
 
-class ResponsePage extends StatelessWidget {
+class ResponsePage extends StatefulWidget {
   static const routeName = '/response';
-
   final LoginResponse data;
-  const ResponsePage({super.key, required this.data});
+  final ApiService api;
+  const ResponsePage({super.key, required this.data, required this.api});
+
+  @override
+  State<ResponsePage> createState() => _ResponsePageState();
+}
+
+class _ResponsePageState extends State<ResponsePage> {
+  Map<String, List<FabricRoll>> _rollsByType = {};
+  String? _selectedFabric;
+  final Set<String> _selectedRolls = {};
+  final TextEditingController _searchCtrl = TextEditingController();
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadRolls();
+    _searchCtrl.addListener(() => setState(() {}));
+  }
+
+  Future<void> _loadRolls() async {
+    setState(() => _loading = true);
+    try {
+      final data = await widget.api.fetchFabricRolls();
+      setState(() {
+        _rollsByType = data;
+      });
+    } on ApiException catch (e) {
+      setState(() => _error = e.message);
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  List<String> get _filteredTypes {
+    final q = _searchCtrl.text.toLowerCase();
+    final types = _rollsByType.keys.toList()..sort();
+    if (q.isEmpty) return types;
+    return types.where((t) => t.toLowerCase().contains(q)).toList();
+  }
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    widget.api.dispose();
+    super.dispose();
+  }
+
+  void _logout() {
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const LoginPage()),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
+    Widget content;
+    if (_loading) {
+      content = const Center(child: CircularProgressIndicator());
+    } else if (_error != null) {
+      content = Center(child: Text(_error!));
+    } else {
+      content = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Hello, ${widget.data.username}',
+            style: const TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _searchCtrl,
+            decoration: const InputDecoration(
+              labelText: 'Search fabric type',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 12),
+          DropdownButton<String>(
+            isExpanded: true,
+            hint: const Text('Select fabric type'),
+            value: _filteredTypes.contains(_selectedFabric)
+                ? _selectedFabric
+                : null,
+            items: _filteredTypes
+                .map(
+                  (t) => DropdownMenuItem(
+                    value: t,
+                    child: Text(t),
+                  ),
+                )
+                .toList(),
+            onChanged: (v) {
+              setState(() {
+                _selectedFabric = v;
+                _selectedRolls.clear();
+              });
+            },
+          ),
+          const SizedBox(height: 16),
+          if (_selectedFabric != null)
+            Expanded(
+              child: ListView(
+                children: _rollsByType[_selectedFabric]!
+                    .map(
+                      (r) => CheckboxListTile(
+                        title: Text(
+                            'Roll ${r.rollNo} (${r.perRollWeight} ${r.unit})'),
+                        subtitle: Text(r.vendorName),
+                        value: _selectedRolls.contains(r.rollNo),
+                        onChanged: (checked) {
+                          setState(() {
+                            if (checked == true) {
+                              _selectedRolls.add(r.rollNo);
+                            } else {
+                              _selectedRolls.remove(r.rollNo);
+                            }
+                          });
+                        },
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+        ],
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Welcome'),
@@ -17,53 +147,13 @@ class ResponsePage extends StatelessWidget {
           IconButton(
             tooltip: 'Logout',
             icon: const Icon(Icons.logout),
-            onPressed: () {
-              Navigator.of(context).pushReplacement(
-                MaterialPageRoute(
-                  builder: (_) => const LoginPage(),
-                ),
-              );
-            },
+            onPressed: _logout,
           ),
         ],
       ),
-      body: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 520),
-          child: Card(
-            margin: const EdgeInsets.all(16),
-            elevation: 2,
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(Icons.verified_user, size: 64),
-                  const SizedBox(height: 12),
-                  Text(
-                    'Hello, ${data.username}',
-                    style: const TextStyle(
-                      fontSize: 26,
-                      fontWeight: FontWeight.w700,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Role: ${data.role}',
-                    style: const TextStyle(fontSize: 18),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 24),
-                  const Text(
-                    'You are now logged in. This page displays the JSON fields returned by the API.',
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: content,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add `FabricRoll` model and API call for fetching fabric rolls
- show cutting manager fabric types and selectable rolls with search
- simplify main app routing and carry auth session after login

## Testing
- ⚠️ `flutter format lib/main.dart lib/models/fabric_roll.dart lib/screens/login_page.dart lib/screens/response_page.dart lib/services/api_service.dart` (failed: command not found)
- ⚠️ `flutter test` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bd2e431f788320aaf322c777a040ee