### PR TITLE
Fix login form encoding and gate fabric view by role

### DIFF
--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -29,8 +29,8 @@ class _LoginPageState extends State<LoginPage> {
 
     setState(() => _loading = true);
     try {
-      // Flip this to true if your server expects form-data instead of JSON:
-      const sendAsForm = false;
+      // Server expects x-www-form-urlencoded credentials
+      const sendAsForm = true;
 
       final data = await _api.login(
         username: _usernameCtrl.text.trim(),

--- a/lib/screens/response_page.dart
+++ b/lib/screens/response_page.dart
@@ -22,11 +22,18 @@ class _ResponsePageState extends State<ResponsePage> {
   bool _loading = true;
   String? _error;
 
+  bool get _isCuttingManager =>
+      widget.data.role.toLowerCase() == 'cutting manager';
+
   @override
   void initState() {
     super.initState();
-    _loadRolls();
-    _searchCtrl.addListener(() => setState(() {}));
+    if (_isCuttingManager) {
+      _loadRolls();
+      _searchCtrl.addListener(() => setState(() {}));
+    } else {
+      _loading = false;
+    }
   }
 
   Future<void> _loadRolls() async {
@@ -66,7 +73,22 @@ class _ResponsePageState extends State<ResponsePage> {
   @override
   Widget build(BuildContext context) {
     Widget content;
-    if (_loading) {
+    if (!_isCuttingManager) {
+      content = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Hello, ${widget.data.username}',
+            style: const TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text('Role: ${widget.data.role}'),
+        ],
+      );
+    } else if (_loading) {
       content = const Center(child: CircularProgressIndicator());
     } else if (_error != null) {
       content = Center(child: Text(_error!));


### PR DESCRIPTION
## Summary
- Send login credentials as `x-www-form-urlencoded`
- Only request fabric rolls when the logged-in user is a Cutting Manager, other roles see basic info

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/screens/login_page.dart lib/screens/response_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd319d029483208785b8679781aab3