### PR TITLE
Fix role recognition for cutting manager

### DIFF
--- a/lib/screens/response_page.dart
+++ b/lib/screens/response_page.dart
@@ -22,8 +22,10 @@ class _ResponsePageState extends State<ResponsePage> {
   bool _loading = true;
   String? _error;
 
-  bool get _isCuttingManager =>
-      widget.data.role.toLowerCase() == 'cutting manager';
+  bool get _isCuttingManager {
+    final role = widget.data.role.toLowerCase().replaceAll('_', ' ');
+    return role == 'cutting manager';
+  }
 
   @override
   void initState() {


### PR DESCRIPTION
## Summary
- Normalize role string to accept `cutting_manager`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd39c16f5c832090f969b109fcaa34