### PR TITLE
Fix FabricRoll weight parsing

### DIFF
--- a/lib/models/fabric_roll.dart
+++ b/lib/models/fabric_roll.dart
@@ -12,10 +12,20 @@ class FabricRoll {
   });
 
   factory FabricRoll.fromJson(Map<String, dynamic> json) {
+    final dynamic rawWeight = json['per_roll_weight'];
+    final double parsedWeight;
+    if (rawWeight is num) {
+      parsedWeight = rawWeight.toDouble();
+    } else if (rawWeight is String) {
+      parsedWeight = double.tryParse(rawWeight) ?? 0.0;
+    } else {
+      parsedWeight = 0.0;
+    }
+
     return FabricRoll(
       rollNo: json['roll_no'] as String,
       unit: json['unit'] as String,
-      perRollWeight: (json['per_roll_weight'] as num).toDouble(),
+      perRollWeight: parsedWeight,
       vendorName: json['vendor_name'] as String,
     );
   }

--- a/test/fabric_roll_test.dart
+++ b/test/fabric_roll_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:aurora_login_app/models/fabric_roll.dart';
+
+void main() {
+  test('FabricRoll.fromJson parses string weight', () {
+    final roll = FabricRoll.fromJson({
+      'roll_no': '001',
+      'unit': 'kg',
+      'per_roll_weight': '12.5',
+      'vendor_name': 'Vendor',
+    });
+
+    expect(roll.perRollWeight, 12.5);
+  });
+
+  test('FabricRoll.fromJson handles invalid weight', () {
+    final roll = FabricRoll.fromJson({
+      'roll_no': '001',
+      'unit': 'kg',
+      'per_roll_weight': 'invalid',
+      'vendor_name': 'Vendor',
+    });
+
+    expect(roll.perRollWeight, 0.0);
+  });
+}
+


### PR DESCRIPTION
## Summary
- handle `per_roll_weight` returned as string when building FabricRoll objects
- add unit tests for string and invalid per_roll_weight values

## Testing
- `dart format lib/models/fabric_roll.dart test/fabric_roll_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4374756483208802f7141cffdc34