### PR TITLE
Improve roll selection feedback

### DIFF
--- a/lib/screens/response_page.dart
+++ b/lib/screens/response_page.dart
@@ -167,6 +167,7 @@ class _ResponsePageState extends State<ResponsePage> {
                   _selectedRolls.add(RollSelection(r));
                   _rollCtrl?.clear();
                 });
+                FocusScope.of(context).unfocus();
               },
             ),
             const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- Unfocus roll number field after selecting a roll so the list of chosen rolls is immediately visible

## Testing
- `dart test` *(fails: command not found)*
- `dart format lib/screens/response_page.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4b2a543483208636d49c8572acfc